### PR TITLE
Add physics-based ball game prototype

### DIFF
--- a/MyGameApp/app/(tabs)/index.tsx
+++ b/MyGameApp/app/(tabs)/index.tsx
@@ -1,75 +1,49 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
-
-import { HelloWave } from '@/components/HelloWave';
-import ParallaxScrollView from '@/components/ParallaxScrollView';
-import { ThemedText } from '@/components/ThemedText';
+import { StyleSheet, Pressable } from 'react-native';
+import { Link } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
 
 export default function HomeScreen() {
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+    <ThemedView style={styles.container}>
+      <ThemedText type="title" style={styles.title}>Physics Ball</ThemedText>
+      <Link href="/game?mode=levels" asChild>
+        <Pressable style={styles.button}>
+          <ThemedText style={styles.buttonText}>Play Levels</ThemedText>
+        </Pressable>
+      </Link>
+      <Link href="/game?mode=versus" asChild>
+        <Pressable style={styles.button}>
+          <ThemedText style={styles.buttonText}>Play vs PC</ThemedText>
+        </Pressable>
+      </Link>
+      <Link href="/game?mode=tournament" asChild>
+        <Pressable style={styles.button}>
+          <ThemedText style={styles.buttonText}>Tournament</ThemedText>
+        </Pressable>
+      </Link>
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
+  container: {
+    flex: 1,
+    justifyContent: 'center',
     alignItems: 'center',
-    gap: 8,
+    gap: 24,
   },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
+  title: {
+    marginBottom: 40,
   },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
+  button: {
+    backgroundColor: '#0a7ea4',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 18,
   },
 });

--- a/MyGameApp/app/_layout.tsx
+++ b/MyGameApp/app/_layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="game" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/MyGameApp/app/game.tsx
+++ b/MyGameApp/app/game.tsx
@@ -1,0 +1,360 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Dimensions, PanResponder, Pressable, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const BALL_RADIUS = 20;
+const GRAVITY = 0.6;
+
+const BALLS = {
+  bouncy: { color: '#0a7ea4', bounce: 0.9 },
+  heavy: { color: '#444', bounce: 0.2 },
+};
+
+const LEVELS = [
+  {
+    start: { x: 60, y: SCREEN_HEIGHT - 100 },
+    goal: { x: SCREEN_WIDTH - 60, y: 60, size: 40 },
+    obstacles: [
+      { x: SCREEN_WIDTH / 2 - 50, y: SCREEN_HEIGHT / 2, width: 100, height: 20 },
+    ],
+  },
+  {
+    start: { x: 60, y: SCREEN_HEIGHT - 100 },
+    goal: { x: SCREEN_WIDTH - 60, y: 60, size: 40 },
+    obstacles: [],
+  },
+];
+
+type BallState = { x: number; y: number; vx: number; vy: number; launched: boolean };
+
+type Mode = 'levels' | 'versus' | 'tournament';
+
+export default function GameScreen() {
+  const { mode = 'levels' } = useLocalSearchParams<{ mode: Mode }>();
+  const [level, setLevel] = useState(0);
+  const [ballType, setBallType] = useState<'bouncy' | 'heavy'>('bouncy');
+  const [unlocked, setUnlocked] = useState<string[]>(['bouncy']);
+  const [message, setMessage] = useState('');
+  const [playerTurn, setPlayerTurn] = useState(true);
+  const [playerScore, setPlayerScore] = useState(0);
+  const [pcScore, setPcScore] = useState(0);
+  const [round, setRound] = useState(1);
+
+  const levelDef = LEVELS[level];
+  const [ball, setBall] = useState<BallState>({
+    x: levelDef.start.x,
+    y: levelDef.start.y,
+    vx: 0,
+    vy: 0,
+    launched: false,
+  });
+
+  const pan = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => !ball.launched && playerTurn,
+      onMoveShouldSetPanResponder: () => !ball.launched && playerTurn,
+      onPanResponderRelease: (_, gesture) => {
+        if (!ball.launched && playerTurn) {
+          setBall((b) => ({
+            ...b,
+            vx: gesture.vx * 30,
+            vy: gesture.vy * 30,
+            launched: true,
+          }));
+          setMessage('');
+        }
+      },
+    })
+  ).current;
+
+  const firstLaunch = useRef(true);
+  const suppressTurn = useRef(false);
+
+  useEffect(() => {
+    let frame: number;
+    const step = () => {
+      setBall((b) => {
+        if (!b.launched) return b;
+        let { x, y, vx, vy } = b;
+        vy += GRAVITY;
+        x += vx;
+        y += vy;
+        const bounce = BALLS[ballType].bounce;
+        if (x < BALL_RADIUS) {
+          x = BALL_RADIUS;
+          vx = -vx * bounce;
+        }
+        if (x > SCREEN_WIDTH - BALL_RADIUS) {
+          x = SCREEN_WIDTH - BALL_RADIUS;
+          vx = -vx * bounce;
+        }
+        if (y < BALL_RADIUS) {
+          y = BALL_RADIUS;
+          vy = -vy * bounce;
+        }
+        if (y > SCREEN_HEIGHT - BALL_RADIUS) {
+          y = SCREEN_HEIGHT - BALL_RADIUS;
+          vy = -vy * bounce;
+          if (Math.abs(vy) < 1) {
+            // stop bouncing
+            vx = 0;
+            vy = 0;
+            return { x, y, vx, vy, launched: false };
+          }
+        }
+        levelDef.obstacles.forEach((o) => {
+          if (
+            x + BALL_RADIUS > o.x &&
+            x - BALL_RADIUS < o.x + o.width &&
+            y + BALL_RADIUS > o.y &&
+            y - BALL_RADIUS < o.y + o.height
+          ) {
+            const overlapX = Math.min(
+              x + BALL_RADIUS - o.x,
+              o.x + o.width - (x - BALL_RADIUS)
+            );
+            const overlapY = Math.min(
+              y + BALL_RADIUS - o.y,
+              o.y + o.height - (y - BALL_RADIUS)
+            );
+            if (overlapX < overlapY) {
+              vx = -vx * bounce;
+              x += vx > 0 ? overlapX : -overlapX;
+            } else {
+              vy = -vy * bounce;
+              y += vy > 0 ? overlapY : -overlapY;
+            }
+          }
+        });
+        return { x, y, vx, vy, launched: true };
+      });
+      frame = requestAnimationFrame(step);
+    };
+    frame = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(frame);
+  }, [ballType, levelDef]);
+
+  // goal detection
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    const goal = levelDef.goal;
+    if (
+      ball.x > goal.x &&
+      ball.x < goal.x + goal.size &&
+      ball.y > goal.y &&
+      ball.y < goal.y + goal.size &&
+      ball.launched
+    ) {
+      setMessage('Scored!');
+      setBall({
+        x: goal.x + goal.size / 2,
+        y: goal.y + goal.size / 2,
+        vx: 0,
+        vy: 0,
+        launched: false,
+      });
+      handleScore();
+    }
+  }, [ball, levelDef, playerTurn]);
+  /* eslint-enable react-hooks/exhaustive-deps */
+
+  // turn management
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    if (firstLaunch.current) {
+      firstLaunch.current = false;
+      return;
+    }
+    if (suppressTurn.current) {
+      suppressTurn.current = false;
+      return;
+    }
+    if (!ball.launched && mode !== 'levels') {
+      if (playerTurn) {
+        setPlayerTurn(false);
+        runPcTurn();
+      } else {
+        finishRound();
+      }
+    }
+  }, [ball.launched, playerTurn, mode]);
+  /* eslint-enable react-hooks/exhaustive-deps */
+
+  const handleScore = () => {
+    if (mode === 'levels') {
+      if (level === 0 && !unlocked.includes('heavy')) {
+        setUnlocked([...unlocked, 'heavy']);
+      }
+      if (level + 1 < LEVELS.length) {
+        const next = level + 1;
+        setLevel(next);
+        const start = LEVELS[next].start;
+        setBall({ x: start.x, y: start.y, vx: 0, vy: 0, launched: false });
+      } else {
+        setMessage('All levels complete');
+      }
+    } else {
+      if (playerTurn) {
+        setPlayerScore((s) => s + 1);
+        setPlayerTurn(false);
+        runPcTurn();
+      } else {
+        setPcScore((s) => s + 1);
+        finishRound();
+      }
+    }
+  };
+
+  const finishRound = () => {
+    setPlayerTurn(true);
+    if (mode === 'tournament') {
+      if (round < 3) {
+        setRound((r) => r + 1);
+        resetBall();
+      } else {
+        const msg =
+          playerScore > pcScore
+            ? 'You won the tournament!'
+            : playerScore < pcScore
+            ? 'PC wins the tournament'
+            : 'Tournament tied';
+        setMessage(msg);
+      }
+    } else {
+      resetBall();
+    }
+  };
+
+  const resetBall = () => {
+    suppressTurn.current = true;
+    const start = LEVELS[level].start;
+    setBall({ x: start.x, y: start.y, vx: 0, vy: 0, launched: false });
+  };
+
+  const runPcTurn = () => {
+    const start = LEVELS[level].start;
+    const goal = levelDef.goal;
+    const vx = (goal.x - start.x) / 30;
+    const vy = (goal.y - start.y) / 30 - (GRAVITY * 30) / 2;
+    setTimeout(() => {
+      setBall({ x: start.x, y: start.y, vx, vy, launched: true });
+    }, 500);
+  };
+
+  const selectBall = (type: 'bouncy' | 'heavy') => {
+    if (unlocked.includes(type)) {
+      setBallType(type);
+    }
+  };
+
+  return (
+    <ThemedView style={styles.container} {...pan.panHandlers}>
+      {levelDef.obstacles.map((o, i) => (
+        <View
+          key={i}
+          style={[styles.obstacle, { left: o.x, top: o.y, width: o.width, height: o.height }]}
+        />
+      ))}
+      <View
+        style={[
+          styles.goal,
+          { left: levelDef.goal.x, top: levelDef.goal.y, width: levelDef.goal.size, height: levelDef.goal.size },
+        ]}
+      />
+      <View
+        style={[
+          styles.ball,
+          {
+            left: ball.x - BALL_RADIUS,
+            top: ball.y - BALL_RADIUS,
+            width: BALL_RADIUS * 2,
+            height: BALL_RADIUS * 2,
+            backgroundColor: playerTurn ? BALLS[ballType].color : 'tomato',
+          },
+        ]}
+      />
+      <View style={styles.ui} pointerEvents="box-none">
+        <View style={styles.ballRow}>
+          <Pressable
+            onPress={() => selectBall('bouncy')}
+            style={[styles.ballChoice, { backgroundColor: BALLS.bouncy.color, opacity: ballType === 'bouncy' ? 1 : 0.5 }]}>
+            <ThemedText style={styles.choiceText}>Bouncy</ThemedText>
+          </Pressable>
+          {unlocked.includes('heavy') && (
+            <Pressable
+              onPress={() => selectBall('heavy')}
+              style={[styles.ballChoice, { backgroundColor: BALLS.heavy.color, opacity: ballType === 'heavy' ? 1 : 0.5 }]}>
+              <ThemedText style={styles.choiceText}>Heavy</ThemedText>
+            </Pressable>
+          )}
+        </View>
+        <ThemedText style={styles.message}>{message}</ThemedText>
+        {mode !== 'levels' && (
+          <ThemedText>{`Player ${playerScore} : PC ${pcScore}`}</ThemedText>
+        )}
+        {mode !== 'levels' && (
+          <ThemedText>{playerTurn ? 'Your turn' : 'PC turn'}</ThemedText>
+        )}
+        <Pressable style={styles.reset} onPress={resetBall}>
+          <ThemedText style={styles.resetText}>Reset</ThemedText>
+        </Pressable>
+      </View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  ball: {
+    position: 'absolute',
+    borderRadius: BALL_RADIUS,
+  },
+  goal: {
+    position: 'absolute',
+    borderWidth: 2,
+    borderColor: '#0a7ea4',
+    backgroundColor: 'rgba(10,126,164,0.2)',
+  },
+  obstacle: {
+    position: 'absolute',
+    backgroundColor: '#999',
+  },
+  ui: {
+    position: 'absolute',
+    top: 40,
+    width: '100%',
+    alignItems: 'center',
+    gap: 12,
+  },
+  ballRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  ballChoice: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+  },
+  choiceText: {
+    color: '#fff',
+  },
+  message: {
+    fontSize: 16,
+  },
+  reset: {
+    marginTop: 12,
+    backgroundColor: '#0a7ea4',
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    borderRadius: 20,
+  },
+  resetText: {
+    color: '#fff',
+  },
+});

--- a/MyGameApp/app/game.tsx
+++ b/MyGameApp/app/game.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Dimensions, PanResponder, Pressable, StyleSheet, View } from 'react-native';
+import { PanResponder, Pressable, StyleSheet, View } from 'react-native';
+import { GLView } from 'expo-gl';
+import { Renderer } from 'expo-three';
+import * as THREE from 'three';
 import { useLocalSearchParams } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
-const BALL_RADIUS = 20;
-const GRAVITY = 0.6;
+const ROOM_SIZE = 8;
+const BALL_RADIUS = 0.3;
+const CUP_RADIUS = 0.5;
+const CUP_HEIGHT = 1;
+const GRAVITY = 9.8;
 
 const BALLS = {
   bouncy: { color: '#0a7ea4', bounce: 0.9 },
@@ -15,214 +20,252 @@ const BALLS = {
 
 const LEVELS = [
   {
-    start: { x: 60, y: SCREEN_HEIGHT - 100 },
-    goal: { x: SCREEN_WIDTH - 60, y: 60, size: 40 },
-    obstacles: [
-      { x: SCREEN_WIDTH / 2 - 50, y: SCREEN_HEIGHT / 2, width: 100, height: 20 },
-    ],
+    start: { x: -4, z: 4 },
+    goal: { x: 4, z: -4 },
   },
   {
-    start: { x: 60, y: SCREEN_HEIGHT - 100 },
-    goal: { x: SCREEN_WIDTH - 60, y: 60, size: 40 },
-    obstacles: [],
+    start: { x: -4, z: 4 },
+    goal: { x: -4, z: -4 },
   },
 ];
 
-type BallState = { x: number; y: number; vx: number; vy: number; launched: boolean };
-
+type BallType = 'bouncy' | 'heavy';
 type Mode = 'levels' | 'versus' | 'tournament';
 
 export default function GameScreen() {
   const { mode = 'levels' } = useLocalSearchParams<{ mode: Mode }>();
   const [level, setLevel] = useState(0);
-  const [ballType, setBallType] = useState<'bouncy' | 'heavy'>('bouncy');
+  const [ballType, setBallType] = useState<BallType>('bouncy');
   const [unlocked, setUnlocked] = useState<string[]>(['bouncy']);
   const [message, setMessage] = useState('');
   const [playerTurn, setPlayerTurn] = useState(true);
   const [playerScore, setPlayerScore] = useState(0);
   const [pcScore, setPcScore] = useState(0);
   const [round, setRound] = useState(1);
-  const [aim, setAim] = useState<{ dx: number; dy: number; active: boolean }>({
-    dx: 0,
-    dy: 0,
-    active: false,
-  });
 
-  const levelDef = LEVELS[level];
-  const [ball, setBall] = useState<BallState>({
-    x: levelDef.start.x,
-    y: levelDef.start.y,
-    vx: 0,
-    vy: 0,
-    launched: false,
-  });
+  const rendererRef = useRef<Renderer>();
+  const sceneRef = useRef<THREE.Scene>();
+  const cameraRef = useRef<THREE.PerspectiveCamera>();
+  const ballRef = useRef<THREE.Mesh>();
+  const cupRef = useRef<THREE.Mesh>();
+  const indicatorRef = useRef<THREE.Mesh>();
+  const velocity = useRef(new THREE.Vector3());
+  const launched = useRef(false);
+  const lastTime = useRef(0);
+  const requestRef = useRef<number>();
+
+  const updateBallColor = React.useCallback(() => {
+    if (ballRef.current) {
+      const color = playerTurn ? BALLS[ballType].color : 'tomato';
+      (ballRef.current.material as THREE.MeshStandardMaterial).color.set(color);
+    }
+  }, [playerTurn, ballType]);
+
+  useEffect(() => {
+    updateBallColor();
+  }, [updateBallColor]);
+
+  const onContextCreate = async (gl: any) => {
+    const { drawingBufferWidth: width, drawingBufferHeight: height } = gl;
+    const renderer = new Renderer({ gl });
+    renderer.setSize(width, height);
+    rendererRef.current = renderer;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#fff');
+    sceneRef.current = scene;
+
+    const camera = new THREE.PerspectiveCamera(70, width / height, 0.1, 1000);
+    camera.position.set(0, 5, 12);
+    camera.lookAt(0, 0, 0);
+    cameraRef.current = camera;
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.8));
+    const dirLight = new THREE.DirectionalLight(0xffffff, 0.6);
+    dirLight.position.set(5, 10, 7);
+    scene.add(dirLight);
+
+    const floor = new THREE.Mesh(
+      new THREE.PlaneGeometry(ROOM_SIZE * 2, ROOM_SIZE * 2),
+      new THREE.MeshStandardMaterial({ color: '#eee' })
+    );
+    floor.rotation.x = -Math.PI / 2;
+    scene.add(floor);
+
+    const wallMat = new THREE.MeshStandardMaterial({ color: '#ddd' });
+    const wallZ = new THREE.BoxGeometry(ROOM_SIZE * 2, ROOM_SIZE, 0.1);
+    const wallX = new THREE.BoxGeometry(0.1, ROOM_SIZE, ROOM_SIZE * 2);
+    const w1 = new THREE.Mesh(wallZ, wallMat);
+    w1.position.set(0, ROOM_SIZE / 2, -ROOM_SIZE);
+    const w2 = w1.clone();
+    w2.position.z = ROOM_SIZE;
+    const w3 = new THREE.Mesh(wallX, wallMat);
+    w3.position.set(-ROOM_SIZE, ROOM_SIZE / 2, 0);
+    const w4 = w3.clone();
+    w4.position.x = ROOM_SIZE;
+    scene.add(w1, w2, w3, w4);
+
+    const levelDef = LEVELS[level];
+
+    const cup = new THREE.Mesh(
+      new THREE.CylinderGeometry(CUP_RADIUS, CUP_RADIUS, CUP_HEIGHT, 32, 1, true),
+      new THREE.MeshStandardMaterial({ color: '#0a7ea4', side: THREE.DoubleSide })
+    );
+    cup.position.set(levelDef.goal.x, CUP_HEIGHT / 2, levelDef.goal.z);
+    scene.add(cup);
+    cupRef.current = cup;
+
+    const ball = new THREE.Mesh(
+      new THREE.SphereGeometry(BALL_RADIUS, 32, 32),
+      new THREE.MeshStandardMaterial({ color: BALLS[ballType].color })
+    );
+    ball.position.set(levelDef.start.x, BALL_RADIUS, levelDef.start.z);
+    scene.add(ball);
+    ballRef.current = ball;
+
+    const indicator = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.05, 0.05, 1, 8),
+      new THREE.MeshBasicMaterial({ color: 'tomato' })
+    );
+    indicator.visible = false;
+    scene.add(indicator);
+    indicatorRef.current = indicator;
+
+    const animate = (time: number) => {
+      requestRef.current = requestAnimationFrame(animate);
+      const delta = lastTime.current ? (time - lastTime.current) / 1000 : 0;
+      lastTime.current = time;
+
+      if (launched.current && ballRef.current) {
+        velocity.current.y -= GRAVITY * delta;
+        ballRef.current.position.addScaledVector(velocity.current, delta);
+
+        const bounce = BALLS[ballType].bounce;
+        const pos = ballRef.current.position;
+        if (pos.y < BALL_RADIUS) {
+          pos.y = BALL_RADIUS;
+          velocity.current.y = -velocity.current.y * bounce;
+          if (Math.abs(velocity.current.y) < 0.1) velocity.current.y = 0;
+        }
+        if (pos.x < -ROOM_SIZE + BALL_RADIUS) {
+          pos.x = -ROOM_SIZE + BALL_RADIUS;
+          velocity.current.x = -velocity.current.x * bounce;
+        }
+        if (pos.x > ROOM_SIZE - BALL_RADIUS) {
+          pos.x = ROOM_SIZE - BALL_RADIUS;
+          velocity.current.x = -velocity.current.x * bounce;
+        }
+        if (pos.z < -ROOM_SIZE + BALL_RADIUS) {
+          pos.z = -ROOM_SIZE + BALL_RADIUS;
+          velocity.current.z = -velocity.current.z * bounce;
+        }
+        if (pos.z > ROOM_SIZE - BALL_RADIUS) {
+          pos.z = ROOM_SIZE - BALL_RADIUS;
+          velocity.current.z = -velocity.current.z * bounce;
+        }
+
+        const goal = LEVELS[level].goal;
+        if (
+          pos.y < CUP_HEIGHT &&
+          Math.hypot(pos.x - goal.x, pos.z - goal.z) < CUP_RADIUS
+        ) {
+          launched.current = false;
+          handleScore();
+          pos.set(goal.x, CUP_HEIGHT / 2, goal.z);
+          velocity.current.set(0, 0, 0);
+        }
+
+        if (
+          !launched.current &&
+          mode !== 'levels' &&
+          Math.abs(velocity.current.x) < 0.01 &&
+          Math.abs(velocity.current.y) < 0.01 &&
+          Math.abs(velocity.current.z) < 0.01
+        ) {
+          if (playerTurn) {
+            setPlayerTurn(false);
+            runPcTurn();
+          } else {
+            finishRound();
+          }
+        }
+      }
+
+      renderer.render(scene, camera);
+      gl.endFrameEXP();
+    };
+    animate(0);
+  };
+
+  const updateIndicator = (dx: number, dy: number) => {
+    const indicator = indicatorRef.current;
+    const ball = ballRef.current;
+    if (!indicator || !ball) return;
+    const shot = new THREE.Vector3(-dx / 50, 0, -dy / 50);
+    const length = shot.length();
+    const dir = shot.clone().normalize();
+    const thickness = Math.max(0.02, 0.1 - Math.min(1, length / 5) * 0.08);
+    indicator.position.copy(ball.position.clone().add(dir.clone().multiplyScalar(length / 2)));
+    indicator.scale.set(thickness / 0.05, length, thickness / 0.05);
+    indicator.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
+  };
 
   const pan = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => !ball.launched && playerTurn,
-      onMoveShouldSetPanResponder: () => !ball.launched && playerTurn,
+      onStartShouldSetPanResponder: () => !launched.current && playerTurn,
+      onMoveShouldSetPanResponder: () => !launched.current && playerTurn,
       onPanResponderGrant: () => {
-        if (!ball.launched && playerTurn) {
-          setAim({ dx: 0, dy: 0, active: true });
+        if (!launched.current && playerTurn) {
+          indicatorRef.current && (indicatorRef.current.visible = true);
         }
       },
       onPanResponderMove: (_, gesture) => {
-        if (!ball.launched && playerTurn) {
-          setAim({ dx: gesture.dx, dy: gesture.dy, active: true });
+        if (!launched.current && playerTurn) {
+          updateIndicator(gesture.dx, gesture.dy);
         }
       },
       onPanResponderRelease: (_, gesture) => {
-        if (!ball.launched && playerTurn) {
-          const scale = 0.2;
-          setBall((b) => ({
-            ...b,
-            vx: -gesture.dx * scale,
-            vy: -gesture.dy * scale,
-            launched: true,
-          }));
-          setAim({ dx: 0, dy: 0, active: false });
+        if (!launched.current && playerTurn) {
+          const scale = 0.6;
+          velocity.current.set(
+            (-gesture.dx / 50) * scale,
+            Math.hypot(gesture.dx, gesture.dy) / 50 * scale * 0.6,
+            (-gesture.dy / 50) * scale
+          );
+          launched.current = true;
+          indicatorRef.current && (indicatorRef.current.visible = false);
           setMessage('');
         }
       },
     })
   ).current;
 
-  const firstLaunch = useRef(true);
-  const suppressTurn = useRef(false);
+  const resetBall = () => {
+    const start = LEVELS[level].start;
+    if (ballRef.current) {
+      ballRef.current.position.set(start.x, BALL_RADIUS, start.z);
+    }
+    velocity.current.set(0, 0, 0);
+    launched.current = false;
+    indicatorRef.current && (indicatorRef.current.visible = false);
+    updateBallColor();
+  };
 
-  useEffect(() => {
-    let frame: number;
-    const step = () => {
-      setBall((b) => {
-        if (!b.launched) return b;
-        let { x, y, vx, vy } = b;
-        vy += GRAVITY;
-        x += vx;
-        y += vy;
-        const bounce = BALLS[ballType].bounce;
-        if (x < BALL_RADIUS) {
-          x = BALL_RADIUS;
-          vx = -vx * bounce;
-        }
-        if (x > SCREEN_WIDTH - BALL_RADIUS) {
-          x = SCREEN_WIDTH - BALL_RADIUS;
-          vx = -vx * bounce;
-        }
-        if (y < BALL_RADIUS) {
-          y = BALL_RADIUS;
-          vy = -vy * bounce;
-        }
-        if (y > SCREEN_HEIGHT - BALL_RADIUS) {
-          y = SCREEN_HEIGHT - BALL_RADIUS;
-          vy = -vy * bounce;
-          if (Math.abs(vy) < 1) {
-            // stop bouncing
-            vx = 0;
-            vy = 0;
-            return { x, y, vx, vy, launched: false };
-          }
-        }
-        levelDef.obstacles.forEach((o) => {
-          if (
-            x + BALL_RADIUS > o.x &&
-            x - BALL_RADIUS < o.x + o.width &&
-            y + BALL_RADIUS > o.y &&
-            y - BALL_RADIUS < o.y + o.height
-          ) {
-            const overlapX = Math.min(
-              x + BALL_RADIUS - o.x,
-              o.x + o.width - (x - BALL_RADIUS)
-            );
-            const overlapY = Math.min(
-              y + BALL_RADIUS - o.y,
-              o.y + o.height - (y - BALL_RADIUS)
-            );
-            if (overlapX < overlapY) {
-              vx = -vx * bounce;
-              x += vx > 0 ? overlapX : -overlapX;
-            } else {
-              vy = -vy * bounce;
-              y += vy > 0 ? overlapY : -overlapY;
-            }
-          }
-        });
-        return { x, y, vx, vy, launched: true };
-      });
-      frame = requestAnimationFrame(step);
-    };
-    frame = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(frame);
-  }, [ballType, levelDef]);
-
-  // goal detection
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    const goal = levelDef.goal;
-    if (
-      ball.x > goal.x &&
-      ball.x < goal.x + goal.size &&
-      ball.y > goal.y &&
-      ball.y < goal.y + goal.size &&
-      ball.launched
-    ) {
-      setMessage('Scored!');
-      setBall({
-        x: goal.x + goal.size / 2,
-        y: goal.y + goal.size / 2,
-        vx: 0,
-        vy: 0,
-        launched: false,
-      });
-      handleScore();
-    }
-  }, [ball, levelDef, playerTurn]);
-  /* eslint-enable react-hooks/exhaustive-deps */
-
-  // turn management
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    if (firstLaunch.current) {
-      firstLaunch.current = false;
-      return;
-    }
-    if (suppressTurn.current) {
-      suppressTurn.current = false;
-      return;
-    }
-    if (!ball.launched && mode !== 'levels') {
-      if (playerTurn) {
-        setPlayerTurn(false);
-        runPcTurn();
-      } else {
-        finishRound();
+  const runPcTurn = () => {
+    const start = LEVELS[level].start;
+    const goal = LEVELS[level].goal;
+    const t = 1.5;
+    const vx = (goal.x - start.x) / t;
+    const vz = (goal.z - start.z) / t;
+    const vy = (CUP_HEIGHT - BALL_RADIUS) / t - (GRAVITY * t) / 2;
+    setTimeout(() => {
+      if (ballRef.current) {
+        ballRef.current.position.set(start.x, BALL_RADIUS, start.z);
+        velocity.current.set(vx, vy, vz);
+        launched.current = true;
+        updateBallColor();
       }
-    }
-  }, [ball.launched, playerTurn, mode]);
-  /* eslint-enable react-hooks/exhaustive-deps */
-
-  const handleScore = () => {
-    if (mode === 'levels') {
-      if (level === 0 && !unlocked.includes('heavy')) {
-        setUnlocked([...unlocked, 'heavy']);
-      }
-      if (level + 1 < LEVELS.length) {
-        const next = level + 1;
-        setLevel(next);
-        const start = LEVELS[next].start;
-        setBall({ x: start.x, y: start.y, vx: 0, vy: 0, launched: false });
-      } else {
-        setMessage('All levels complete');
-      }
-    } else {
-      if (playerTurn) {
-        setPlayerScore((s) => s + 1);
-        setPlayerTurn(false);
-        runPcTurn();
-      } else {
-        setPcScore((s) => s + 1);
-        finishRound();
-      }
-    }
+    }, 500);
   };
 
   const finishRound = () => {
@@ -245,85 +288,56 @@ export default function GameScreen() {
     }
   };
 
-  const resetBall = () => {
-    suppressTurn.current = true;
-    const start = LEVELS[level].start;
-    setBall({ x: start.x, y: start.y, vx: 0, vy: 0, launched: false });
+  const handleScore = () => {
+    if (mode === 'levels') {
+      if (level === 0 && !unlocked.includes('heavy')) {
+        setUnlocked([...unlocked, 'heavy']);
+      }
+      if (level + 1 < LEVELS.length) {
+        const next = level + 1;
+        setLevel(next);
+        const start = LEVELS[next].start;
+        if (ballRef.current) {
+          ballRef.current.position.set(start.x, BALL_RADIUS, start.z);
+        }
+        velocity.current.set(0, 0, 0);
+      } else {
+        setMessage('All levels complete');
+      }
+    } else {
+      if (playerTurn) {
+        setPlayerScore((s) => s + 1);
+        setPlayerTurn(false);
+        runPcTurn();
+      } else {
+        setPcScore((s) => s + 1);
+        finishRound();
+      }
+    }
   };
 
-  const runPcTurn = () => {
-    const start = LEVELS[level].start;
-    const goal = levelDef.goal;
-    const vx = (goal.x - start.x) / 30;
-    const vy = (goal.y - start.y) / 30 - (GRAVITY * 30) / 2;
-    setTimeout(() => {
-      setBall({ x: start.x, y: start.y, vx, vy, launched: true });
-    }, 500);
-  };
-
-  const selectBall = (type: 'bouncy' | 'heavy') => {
+  const selectBall = (type: BallType) => {
     if (unlocked.includes(type)) {
       setBallType(type);
     }
   };
 
-  const aimLength = Math.hypot(aim.dx, aim.dy);
-  const aimThickness = Math.max(2, 10 - Math.min(1, aimLength / 150) * 8);
-  const aimAngle = Math.atan2(-aim.dy, -aim.dx);
-
   return (
     <ThemedView style={styles.container} {...pan.panHandlers}>
-      <View style={styles.board}>
-        {levelDef.obstacles.map((o, i) => (
-          <View
-            key={i}
-            style={[styles.obstacle, { left: o.x, top: o.y, width: o.width, height: o.height }]}
-          />
-        ))}
-        <View
-          style={[
-            styles.goal,
-            { left: levelDef.goal.x, top: levelDef.goal.y, width: levelDef.goal.size, height: levelDef.goal.size },
-          ]}
-        />
-        <View
-          style={[
-            styles.ball,
-            {
-              left: ball.x - BALL_RADIUS,
-              top: ball.y - BALL_RADIUS,
-              width: BALL_RADIUS * 2,
-              height: BALL_RADIUS * 2,
-              backgroundColor: playerTurn ? BALLS[ballType].color : 'tomato',
-            },
-          ]}
-        />
-        {aim.active && (
-          <View
-            style={[
-              styles.aimLine,
-              {
-                width: aimLength,
-                height: aimThickness,
-                left: ball.x,
-                top: ball.y - aimThickness / 2,
-                transform: [{ rotate: `${aimAngle}rad` }],
-              },
-            ]}
-          />
-        )}
-      </View>
+      <GLView style={styles.board} onContextCreate={onContextCreate} />
       <View style={styles.ui} pointerEvents="box-none">
         <View style={styles.ballRow}>
           <Pressable
             onPress={() => selectBall('bouncy')}
-            style={[styles.ballChoice, { backgroundColor: BALLS.bouncy.color, opacity: ballType === 'bouncy' ? 1 : 0.5 }]}>
+            style={[styles.ballChoice, { backgroundColor: BALLS.bouncy.color, opacity: ballType === 'bouncy' ? 1 : 0.5 }]}
+          >
             <ThemedText style={styles.choiceText}>Bouncy</ThemedText>
           </Pressable>
           {unlocked.includes('heavy') && (
             <Pressable
               onPress={() => selectBall('heavy')}
-              style={[styles.ballChoice, { backgroundColor: BALLS.heavy.color, opacity: ballType === 'heavy' ? 1 : 0.5 }]}>
+              style={[styles.ballChoice, { backgroundColor: BALLS.heavy.color, opacity: ballType === 'heavy' ? 1 : 0.5 }]}
+            >
               <ThemedText style={styles.choiceText}>Heavy</ThemedText>
             </Pressable>
           )}
@@ -350,30 +364,6 @@ const styles = StyleSheet.create({
   },
   board: {
     flex: 1,
-  },
-  ball: {
-    position: 'absolute',
-    borderRadius: BALL_RADIUS,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.3,
-    shadowRadius: 2,
-    elevation: 3,
-  },
-  goal: {
-    position: 'absolute',
-    borderWidth: 2,
-    borderColor: '#0a7ea4',
-    backgroundColor: 'rgba(10,126,164,0.2)',
-  },
-  obstacle: {
-    position: 'absolute',
-    backgroundColor: '#999',
-  },
-  aimLine: {
-    position: 'absolute',
-    backgroundColor: 'tomato',
-    borderRadius: 4,
   },
   ui: {
     position: 'absolute',
@@ -408,3 +398,4 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
 });
+

--- a/MyGameApp/package.json
+++ b/MyGameApp/package.json
@@ -28,6 +28,8 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
+    "expo-gl": "~13.0.0",
+    "expo-three": "^7.0.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
@@ -36,7 +38,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "three": "^0.167.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- replace home screen with mode selector
- add game screen with basic physics, bouncing levels and PC/tournament modes
- register game screen in navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7cd76d4e08330a44a24923d9887a3